### PR TITLE
Adds --raw-guid flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,13 +19,14 @@ NAME:
    log-cache -
 
 USAGE:
-   log-cache [options] <app-guid>
+   log-cache [options] <app>
 
 OPTIONS:
    -start-time       Start of query range in UNIX nanoseconds.
    -end-time         End of query range in UNIX nanoseconds.
    -envelope-type    Envelope type filter. Available filters: 'log', 'counter', 'gauge', 'timer', and 'event'.
    -limit            Limit the number of envelopes to return. Defaults to 100. Max value is 1000.
+   -raw-guid         Do not convert app name into a guid.
 ```
 
 [log-cache]: https://code.cloudfoundry.org/log-cache-release

--- a/internal/command/log_cache.go
+++ b/internal/command/log_cache.go
@@ -127,6 +127,7 @@ func newOptions(cli plugin.CliConnection, args []string, log Logger) (options, e
 	envelopeType := f.String("envelope-type", "", "")
 	limit := f.Uint64("limit", 0, "")
 	recent := f.Bool("recent", false, "")
+	rawGuid := f.Bool("raw-guid", false, "")
 
 	err := f.Parse(args)
 	if err != nil {
@@ -137,12 +138,17 @@ func newOptions(cli plugin.CliConnection, args []string, log Logger) (options, e
 		return options{}, fmt.Errorf("Expected 1 argument, got %d.", len(f.Args()))
 	}
 
+	guid := f.Args()[0]
+	if !*rawGuid {
+		guid = getAppGuid(f.Args()[0], cli, log)
+	}
+
 	o := options{
 		startTime:    time.Unix(0, *start),
 		endTime:      time.Unix(0, *end),
 		envelopeType: translateEnvelopeType(*envelopeType),
 		limit:        *limit,
-		guid:         getAppGuid(f.Args()[0], cli, log),
+		guid:         guid,
 		appName:      f.Args()[0],
 	}
 

--- a/internal/command/log_cache_test.go
+++ b/internal/command/log_cache_test.go
@@ -245,6 +245,13 @@ var _ = Describe("LogCache", func() {
 		Expect(cliConn.cliCommandArgs[2]).To(Equal("--guid"))
 	})
 
+	It("does not request app guid when given --raw-guid flag", func() {
+		args := []string{"some-app", "--raw-guid"}
+		command.LogCache(cliConn, args, httpClient, logger)
+
+		Expect(cliConn.cliCommandArgs).To(HaveLen(0))
+	})
+
 	It("places the JWT in the 'Authorization' header", func() {
 		args := []string{"some-app"}
 		cliConn.accessToken = "bearer some-token"

--- a/main.go
+++ b/main.go
@@ -44,13 +44,14 @@ func (c *LogCacheCLI) GetMetadata() plugin.PluginMetadata {
 			{
 				Name: "log-cache",
 				UsageDetails: plugin.Usage{
-					Usage: "log-cache [options] <app-guid>",
+					Usage: "log-cache [options] <app>",
 					Options: map[string]string{
 						"start-time":    "Start of query range in UNIX nanoseconds.",
 						"end-time":      "End of query range in UNIX nanoseconds.",
 						"envelope-type": "Envelope type filter. Available filters: 'log', 'counter', 'gauge', 'timer', and 'event'.",
 						"limit":         "Limit the number of envelopes to return. Defaults to 100. Max value is 1000.",
 						"recent":        "Show all logs in cache for the app. If given, all other flags are ignored.",
+						"raw-guid":      "Do not convert app name into a guid.",
 					},
 				},
 			},


### PR DESCRIPTION
This prevents the CLI from converting a given name into a app-guid. This is useful for an operator to query components (e.g., doppler).